### PR TITLE
Create Job class to hold commands

### DIFF
--- a/src/experi/commands.py
+++ b/src/experi/commands.py
@@ -8,7 +8,7 @@
 
 """Command class."""
 
-from typing import Any, Dict, List
+from typing import Any, Dict, List, Optional
 
 
 class Command(object):
@@ -63,9 +63,11 @@ class Job(object):
     """A task to perfrom within a simulation."""
     commands: List[Command]
     shell: str = "bash"
+    scheduler_options: Optional[Dict[str, Any]] = None
 
-    def __init__(self, commands) -> None:
+    def __init__(self, commands, scheduler_options=None) -> None:
         self.commands = commands
+        self.scheduler_options = scheduler_options
 
     def __iter__(self):
         return iter(self.commands)

--- a/src/experi/commands.py
+++ b/src/experi/commands.py
@@ -8,10 +8,11 @@
 
 """Command class."""
 
-from typing import Any, Dict, NamedTuple
+from typing import Any, Dict, List
 
 
 class Command(object):
+    """A command to be run for an experiment."""
     _cmd: str
     variables: Dict[str, Any]
     _creates: str = ""
@@ -56,3 +57,30 @@ class Command(object):
 
     def __hash__(self):
         return hash(self.cmd)
+
+
+class Job(object):
+    """A task to perfrom within a simulation."""
+    commands: List[Command]
+    shell: str = "bash"
+
+    def __init__(self, commands) -> None:
+        self.commands = commands
+
+    def __iter__(self):
+        return iter(self.commands)
+
+    def __len__(self) -> int:
+        return len(self.commands)
+
+    def as_bash_array(self) -> str:
+        """Return a representation as a bash array.
+
+        This creates a string formatted as a bash arry containing all the commands in the job.
+
+        """
+        return_string = "( \\\n"
+        for command in self:
+            return_string += '"' + command.cmd.strip() + '" \\\n'
+        return_string += ")"
+        return return_string

--- a/src/experi/pbs.py
+++ b/src/experi/pbs.py
@@ -127,7 +127,7 @@ def pbs_header(**kwargs):
     return header_string
 
 
-def create_pbs_file(job: Job, pbs_options: Mapping[str, Any]) -> str:
+def create_pbs_file(job: Job) -> str:
     """Substitute values into a template pbs file.
 
     This substitues the values in the pbs section of the input file
@@ -135,7 +135,10 @@ def create_pbs_file(job: Job, pbs_options: Mapping[str, Any]) -> str:
     default options.
 
     """
-    pbs_options = deepcopy(pbs_options)
+    if job.scheduler_options is None:
+        pbs_options = {}
+    else:
+        pbs_options = deepcopy(job.scheduler_options)
     try:
         setup_string = parse_setup(pbs_options["setup"])
         del pbs_options["setup"]

--- a/src/experi/run.py
+++ b/src/experi/run.py
@@ -184,7 +184,7 @@ def process_structure(
     yield from process_jobs(jobs_dict, variables, scheduler_options)
 
 
-def run_commands(
+def run_jobs(
     jobs: Iterator[Job], scheduler: str = "shell", directory=Path.cwd()
 ) -> None:
     assert scheduler in ["shell", "pbs"]
@@ -337,4 +337,4 @@ def main(input_file) -> None:
     structure = read_file(input_file)
     scheduler = process_scheduler(structure)
     jobs = process_structure(structure, scheduler)
-    run_commands(jobs, scheduler, input_file.parent)
+    run_jobs(jobs, scheduler, input_file.parent)

--- a/test/commands_test.py
+++ b/test/commands_test.py
@@ -17,14 +17,16 @@ from experi.run import uniqueify
 def test_command_simple():
     cmd = "test"
     command = Command(cmd=cmd)
-    assert command.cmd == cmd
+    assert command.cmd == [cmd]
+    assert str(command) == cmd
 
 
 def test_command_substitution():
     cmd = "test {var1}"
     variables = {"var1": "1.0"}
     command = Command(cmd=cmd, variables=variables)
-    assert command.cmd == cmd.format(**variables)
+    assert command.cmd == [cmd.format(**variables)]
+    assert str(command) == cmd.format(**variables)
 
 
 def test_creates_substitution():
@@ -32,7 +34,8 @@ def test_creates_substitution():
     creates = "test.out"
     variables = {"var1": "1.0"}
     command = Command(cmd=cmd, creates=creates, variables=variables)
-    assert command.cmd == cmd.format(creates=creates, **variables)
+    assert command.cmd == [cmd.format(creates=creates, **variables)]
+    assert str(command) == cmd.format(creates=creates, **variables)
 
 
 def test_requires_substitution():
@@ -40,7 +43,8 @@ def test_requires_substitution():
     requires = "test.in"
     variables = {"var1": "1.0"}
     command = Command(cmd=cmd, requires=requires, variables=variables)
-    assert command.cmd == cmd.format(requires=requires, **variables)
+    assert command.cmd == [cmd.format(requires=requires, **variables)]
+    assert str(command) == cmd.format(requires=requires, **variables)
 
 
 def test_creates_complex_substitution():
@@ -49,7 +53,8 @@ def test_creates_complex_substitution():
     variables = {"var1": "1.0"}
     command = Command(cmd=cmd, creates=creates, variables=variables)
     creates = creates.format(**variables)
-    assert command.cmd == cmd.format(creates=creates, **variables)
+    assert command.cmd == [cmd.format(creates=creates, **variables)]
+    assert str(command) == cmd.format(creates=creates, **variables)
 
 
 def test_requires_complex_substitution():
@@ -58,13 +63,14 @@ def test_requires_complex_substitution():
     variables = {"var1": "1.0"}
     command = Command(cmd=cmd, requires=requires, variables=variables)
     requires = requires.format(**variables)
-    assert command.cmd == cmd.format(requires=requires, **variables)
+    assert command.cmd == [cmd.format(requires=requires, **variables)]
+    assert str(command) == cmd.format(requires=requires, **variables)
 
 
 def test_hashable_command():
     cmd = "test"
     command = Command(cmd=cmd)
-    assert hash(command) == hash(cmd)
+    assert hash(command) == hash((cmd,))
     cmd_dict = {command: "Success"}
     assert cmd_dict.get(command) == "Success"
 
@@ -73,3 +79,9 @@ def test_uniqueify_command():
     cmd_list = [Command(cmd="test") for _ in range(5)]
     unique_commands = uniqueify(cmd_list)
     assert len(unique_commands) == 1
+
+
+def test_cmd_list():
+    command = Command(cmd=["test"] * 5)
+    assert command.cmd == ["test"] * 5
+    assert str(command) == " && ".join(["test"] * 5)

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -1,0 +1,20 @@
+#! /usr/bin/env python
+# -*- coding: utf-8 -*-
+# vim:fenc=utf-8
+#
+# Copyright © 2018 Malcolm Ramsay <malramsay64@gmail.com>
+#
+# Distributed under terms of the MIT license.
+
+"""Utility fixtures for use within pytest."""
+
+from tempfile import TemporaryDirectory
+from pathlib import Path
+
+import pytest
+
+
+@pytest.fixture(scope="function")
+def tmp_dir():
+    with TemporaryDirectory() as dst:
+        yield Path(dst)

--- a/test/data/iter/command_list_test.yml
+++ b/test/data/iter/command_list_test.yml
@@ -1,0 +1,13 @@
+# Test the command class will take a list of commands
+
+jobs:
+  - command:
+    - echo {var1}
+    - echo {var2}
+
+variables:
+  var1: [1, 2]
+  var2: [3, 4]
+
+result: 
+  - ["echo 1 && echo 3", "echo 1 && echo 4", "echo 2 && echo 3", "echo 2 && echo 4"]

--- a/test/iter_test.py
+++ b/test/iter_test.py
@@ -18,7 +18,7 @@ import pytest
 
 from experi.run import process_command, process_jobs, read_file, variable_matrix
 
-test_cases = sorted(Path("test/data/iter").glob("test*.yml"))
+test_cases = sorted(Path("test/data/iter").glob("*.yml"))
 
 
 @pytest.mark.xfail(
@@ -44,5 +44,5 @@ def test_behaviour(test_file):
         jobs = process_jobs(command_list, variables)
 
     for job in jobs:
-        result.append([command.cmd for command in job])
+        result.append([str(command) for command in job])
     assert result == structure["result"]

--- a/test/iter_test.py
+++ b/test/iter_test.py
@@ -16,9 +16,9 @@ from pathlib import Path
 
 import pytest
 
-from experi.run import process_command, read_file, variable_matrix
+from experi.run import process_command, process_jobs, read_file, variable_matrix
 
-test_cases = Path("test/data/iter").glob("test*.yml")
+test_cases = sorted(Path("test/data/iter").glob("test*.yml"))
 
 
 @pytest.mark.xfail(
@@ -26,11 +26,23 @@ test_cases = Path("test/data/iter").glob("test*.yml")
 )
 @pytest.mark.parametrize("test_file", test_cases)
 def test_behaviour(test_file):
-    test = read_file(test_file)
-    variables = list(variable_matrix(test["variables"]))
+    structure = read_file(test_file)
+    variables = list(variable_matrix(structure["variables"]))
     print(variables)
-    print(test["command"])
     result = []
-    for command_group in process_command(test["command"], variables):
-        result.append([command.cmd for command in command_group])
-    assert result == test["result"]
+
+    jobs_dict = structure.get("jobs")
+    if jobs_dict is not None:
+        jobs = process_jobs(jobs_dict, variables)
+    else:
+        input_command = structure.get("command")
+        if isinstance(input_command, list):
+            command_list = [{"command": cmd} for cmd in input_command]
+        else:
+            command_list = [{"command": input_command}]
+
+        jobs = process_jobs(command_list, variables)
+
+    for job in jobs:
+        result.append([command.cmd for command in job])
+    assert result == structure["result"]

--- a/test/pbs_test.py
+++ b/test/pbs_test.py
@@ -14,7 +14,7 @@ import pytest
 
 from experi.commands import Command, Job
 from experi.pbs import create_pbs_file
-from experi.run import process_structure, read_file
+from experi.run import process_structure, read_file, run_commands
 
 DEFAULT_PBS = """#!/bin/bash
 #PBS -N experi
@@ -48,13 +48,13 @@ def test_jobs_as_bash_array(job, result):
 
 
 def test_default_pbs():
-    assert create_pbs_file(Job([Command("echo 1")]), {}) == DEFAULT_PBS
+    assert create_pbs_file(Job([Command("echo 1")])) == DEFAULT_PBS
 
 
-def test_pbs_creation():
-    directory = Path("test/data/pbs")
-    structure = read_file(directory / "experiment.yml")
-    process_structure(structure, directory)
+def test_pbs_creation(tmp_dir):
+    structure = read_file("test/data/pbs/experiment.yml")
+    jobs = process_structure(structure, scheduler="pbs")
+    run_commands(jobs, "pbs", tmp_dir)
     expected = structure["result"]
-    with (directory / "experi_00.pbs").open("r") as result:
+    with (tmp_dir / "experi_00.pbs").open("r") as result:
         assert result.read().strip() == expected.strip()

--- a/test/pbs_test.py
+++ b/test/pbs_test.py
@@ -14,7 +14,7 @@ import pytest
 
 from experi.commands import Command, Job
 from experi.pbs import create_pbs_file
-from experi.run import process_file, read_file
+from experi.run import process_structure, read_file
 
 DEFAULT_PBS = """#!/bin/bash
 #PBS -N experi
@@ -43,7 +43,7 @@ ${COMMAND[$PBS_ARRAY_INDEX]}
         ),
     ],
 )
-def test_jobs_as_bash_arrayh(job, result):
+def test_jobs_as_bash_array(job, result):
     assert job.as_bash_array() == result
 
 
@@ -53,7 +53,8 @@ def test_default_pbs():
 
 def test_pbs_creation():
     directory = Path("test/data/pbs")
-    process_file(directory / "experiment.yml")
-    expected = read_file(directory / "experiment.yml")["result"]
+    structure = read_file(directory / "experiment.yml")
+    process_structure(structure, directory)
+    expected = structure["result"]
     with (directory / "experi_00.pbs").open("r") as result:
         assert result.read().strip() == expected.strip()

--- a/test/pbs_test.py
+++ b/test/pbs_test.py
@@ -12,8 +12,8 @@ from pathlib import Path
 
 import pytest
 
-from experi.commands import Command
-from experi.pbs import commands2bash_array, create_pbs_file
+from experi.commands import Command, Job
+from experi.pbs import create_pbs_file
 from experi.run import process_file, read_file
 
 DEFAULT_PBS = """#!/bin/bash
@@ -34,18 +34,21 @@ ${COMMAND[$PBS_ARRAY_INDEX]}
 
 
 @pytest.mark.parametrize(
-    "command, result",
+    "job, result",
     [
-        ([Command("echo 1")], '( \\\n"echo 1" \\\n)'),
-        ([Command("echo 1"), Command("echo 2")], '( \\\n"echo 1" \\\n"echo 2" \\\n)'),
+        (Job([Command("echo 1")]), '( \\\n"echo 1" \\\n)'),
+        (
+            Job([Command("echo 1"), Command("echo 2")]),
+            '( \\\n"echo 1" \\\n"echo 2" \\\n)',
+        ),
     ],
 )
-def test_commands2bash(command, result):
-    assert commands2bash_array(command) == result
+def test_jobs_as_bash_arrayh(job, result):
+    assert job.as_bash_array() == result
 
 
 def test_default_pbs():
-    assert create_pbs_file([Command("echo 1")], {}) == DEFAULT_PBS
+    assert create_pbs_file(Job([Command("echo 1")]), {}) == DEFAULT_PBS
 
 
 def test_pbs_creation():

--- a/test/pbs_test.py
+++ b/test/pbs_test.py
@@ -8,13 +8,11 @@
 
 """Test the building of pbs files."""
 
-from pathlib import Path
-
 import pytest
 
 from experi.commands import Command, Job
 from experi.pbs import create_pbs_file
-from experi.run import process_structure, read_file, run_commands
+from experi.run import process_structure, read_file, run_jobs
 
 DEFAULT_PBS = """#!/bin/bash
 #PBS -N experi
@@ -54,7 +52,7 @@ def test_default_pbs():
 def test_pbs_creation(tmp_dir):
     structure = read_file("test/data/pbs/experiment.yml")
     jobs = process_structure(structure, scheduler="pbs")
-    run_commands(jobs, "pbs", tmp_dir)
+    run_jobs(jobs, "pbs", tmp_dir)
     expected = structure["result"]
     with (tmp_dir / "experi_00.pbs").open("r") as result:
         assert result.read().strip() == expected.strip()

--- a/test/run_test.py
+++ b/test/run_test.py
@@ -1,0 +1,64 @@
+#! /usr/bin/env python
+# -*- coding: utf-8 -*-
+# vim:fenc=utf-8
+#
+# Copyright © 2018 Malcolm Ramsay <malramsay64@gmail.com>
+#
+# Distributed under terms of the MIT license.
+
+"""Test the running of commands."""
+
+from pathlib import Path
+from tempfile import TemporaryDirectory
+from typing import Iterator
+
+import pytest
+
+from experi.commands import Command, Job
+from experi.run import run_bash_commands
+
+
+@pytest.fixture(scope="function")
+def tmp_dir():
+    with TemporaryDirectory() as dst:
+        yield dst
+
+
+@pytest.fixture
+def create_jobs():
+
+    def _create_jobs(command: str) -> Iterator[Job]:
+        yield Job([Command(command)])
+
+    return _create_jobs
+
+
+@pytest.mark.parametrize(
+    "command",
+    [
+        "false || mkdir passed",
+        "mkdir passed || mkdir failed",
+        "true && mkdir passed",
+        "true && {{ false || mkdir passed; }}",
+        "echo 'hello world' > passed",
+        "echo -e 'hello world\ntest' > passed",
+        "if [ 1 -eq 1 ]; then touch passed; fi",
+        """
+            if [ 0 -eq 1 ]; then
+                touch failed
+            else
+                touch passed
+            fi
+        """,
+    ],
+)
+def test_bash_operators(tmp_dir, create_jobs, command):
+    """Test bash operators work.
+
+    The commands are structured to create a file or directory "passed" when upon sucess.
+
+    """
+    jobs = create_jobs(command)
+    run_bash_commands(jobs, tmp_dir)
+    assert (Path(tmp_dir) / "passed").exists()
+    assert not (Path(tmp_dir) / "failed").exists()

--- a/test/run_test.py
+++ b/test/run_test.py
@@ -9,19 +9,12 @@
 """Test the running of commands."""
 
 from pathlib import Path
-from tempfile import TemporaryDirectory
 from typing import Iterator
 
 import pytest
 
 from experi.commands import Command, Job
-from experi.run import run_bash_commands
-
-
-@pytest.fixture(scope="function")
-def tmp_dir():
-    with TemporaryDirectory() as dst:
-        yield dst
+from experi.run import process_scheduler, run_bash_jobs
 
 
 @pytest.fixture
@@ -59,6 +52,19 @@ def test_bash_operators(tmp_dir, create_jobs, command):
 
     """
     jobs = create_jobs(command)
-    run_bash_commands(jobs, tmp_dir)
-    assert (Path(tmp_dir) / "passed").exists()
-    assert not (Path(tmp_dir) / "failed").exists()
+    run_bash_jobs(jobs, tmp_dir)
+    assert (tmp_dir / "passed").exists()
+    assert not (tmp_dir / "failed").exists()
+
+
+@pytest.mark.parametrize(
+    "structure",
+    [
+        {"result": "shell"},
+        {"shell": True, "result": "shell"},
+        {"shell": False, "pbs": "true", "result": "pbs"},
+        {"shell": False, "pbs": False, "result": "shell"},
+    ],
+)
+def test_process_scheduler(structure):
+    assert process_scheduler(structure) == structure["result"]

--- a/test/variables_test.py
+++ b/test/variables_test.py
@@ -23,6 +23,6 @@ def test_variable_generality(variable_start, variable_end):
     var_dict = {variable_name: [1, 2, 3, 4, 5]}
     variables = variable_matrix(var_dict)
     cmd_list = [
-        i.cmd for i in process_command("echo {" + variable_name + "}", variables)
+        str(cmd) for cmd in process_command("echo {" + variable_name + "}", variables)
     ]
     assert cmd_list == ["echo 1", "echo 2", "echo 3", "echo 4", "echo 5"]

--- a/test/variables_test.py
+++ b/test/variables_test.py
@@ -22,11 +22,7 @@ def test_variable_generality(variable_start, variable_end):
     variable_name = variable_start + variable_end
     var_dict = {variable_name: [1, 2, 3, 4, 5]}
     variables = variable_matrix(var_dict)
-    for cmd_list in process_command("echo {" + variable_name + "}", variables):
-        assert [i.cmd for i in cmd_list] == [
-            "echo 1",
-            "echo 2",
-            "echo 3",
-            "echo 4",
-            "echo 5",
-        ]
+    cmd_list = [
+        i.cmd for i in process_command("echo {" + variable_name + "}", variables)
+    ]
+    assert cmd_list == ["echo 1", "echo 2", "echo 3", "echo 4", "echo 5"]


### PR DESCRIPTION
I now have a much better understanding of the structure of what this package should be, which
requires the creation of the Job class. 

The idea is that an experiment will have Jobs, which are dependent on each other. The Job class
represents the PBS submission script and will contain all the variables for the running of the job
on the scheduler. This means each Job can be specified with different requirements, i.e. only run
with 1 cpu instead of 12.

The Job class will also assist in providing consistency between the various job submission types,
providing the common interface.