### PR TITLE
Support for skipping simulations when output files exist

### DIFF
--- a/test/cli_test.py
+++ b/test/cli_test.py
@@ -8,6 +8,9 @@
 
 """Test CLI interaction."""
 
+import textwrap
+from pathlib import Path
+
 import pytest
 from click.testing import CliRunner
 
@@ -36,3 +39,39 @@ def test_missing_input_file(runner):
         assert result.exit_code != 0
         result = runner.invoke(main, ["-f", "nonexistant_file.yml"])
         assert result.exit_code != 0
+
+
+@pytest.fixture(params=["", "pbs: True"], ids=["bash", "pbs"])
+def test_file(request):
+    return textwrap.dedent(
+        f"""
+        jobs:
+          - command:
+              cmd: echo contents > {{creates}}
+              creates: test.out
+
+        variables:
+            var1: 0
+
+        {request.param}
+    """
+    )
+
+
+def test_dry_run(runner, test_file):
+    with runner.isolated_filesystem():
+        with open("experiment.yml", "w") as dst:
+            dst.write(test_file)
+
+        result = runner.invoke(main, ["--dry-run"])
+        print(result)
+        assert result.exit_code == 0, result.exception
+
+        if "pbs" in test_file:
+            print(result.output)
+            assert "qsub" in result.output
+            assert Path("experi_00.pbs").is_file()
+        else:
+            print(result.output)
+            assert "bash -c" in result.output
+            assert not Path("experi_00.pbs").is_file()

--- a/test/run_test.py
+++ b/test/run_test.py
@@ -14,7 +14,7 @@ from typing import Iterator
 import pytest
 
 from experi.commands import Command, Job
-from experi.run import process_scheduler, run_bash_jobs
+from experi.run import process_scheduler, run_bash_jobs, run_pbs_jobs
 
 
 @pytest.fixture
@@ -100,3 +100,11 @@ def test_dependencies_list(tmp_dir):
             assert "success" in create_files[i].read_text()
         else:
             assert f"contents{i}" in create_files[i].read_text()
+
+
+def test_dry_run(tmp_dir):
+    command = Command(cmd="echo contents > {creates}", creates="test")
+    jobs = [Job([command], directory=Path(tmp_dir))]
+    create_file = tmp_dir / "test"
+    run_bash_jobs(jobs, tmp_dir, dry_run=True)
+    assert not create_file.exists()


### PR DESCRIPTION
This brings support for being able to skip the processing to recreate files that already
exist. This is not smart, it only looks for the existence of the file, not that it has
contents or that it has been recently updated. This functionality is activated by
passing the command line option `--use-dependencies`. The default functionality remains
to run every file.