### PR TITLE
Wrapper function to provide python API

### DIFF
--- a/examples/launch_experi.py
+++ b/examples/launch_experi.py
@@ -1,0 +1,3 @@
+from experi.run import launch as launch_experi
+
+launch_experi("demo.yml")

--- a/src/experi/run.py
+++ b/src/experi/run.py
@@ -574,6 +574,20 @@ def _set_verbosity(ctx, param, value):
         logging.basicConfig(level=logging.DEBUG)
 
 
+def launch(input_file="experiment.yml", use_dependencies=False, dry_run=False) -> None:
+    # This function provides an API to access experi's functionality from within
+    # python scripts, as an alternative to the command-line interface
+
+    # Process and run commands
+    input_file = Path(input_file)
+    structure = read_file(input_file)
+    scheduler = process_scheduler(structure)
+    jobs = process_structure(
+        structure, scheduler, Path(input_file.parent), use_dependencies
+    )
+    run_jobs(jobs, scheduler, input_file.parent, dry_run)
+
+
 @click.command()
 @click.version_option()
 @click.option(
@@ -606,11 +620,4 @@ def _set_verbosity(ctx, param, value):
     help="Increase the verbosity of logging events.",
 )
 def main(input_file, use_dependencies, dry_run) -> None:
-    # Process and run commands
-    input_file = Path(input_file)
-    structure = read_file(input_file)
-    scheduler = process_scheduler(structure)
-    jobs = process_structure(
-        structure, scheduler, Path(input_file.parent), use_dependencies
-    )
-    run_jobs(jobs, scheduler, input_file.parent, dry_run)
+    launch(input_file, use_dependencies, dry_run)


### PR DESCRIPTION
Intended to address #58, by just abstracting the click decorators to another function which doesn't have to be called, as in [this comment](https://github.com/pallets/click/issues/40#issuecomment-232347953).

Let me know what you think about this, and about having a python API in general.

