### PR TITLE
Some small fixes for running on slurm

### DIFF
--- a/examples/launch_experi.py
+++ b/examples/launch_experi.py
@@ -1,0 +1,3 @@
+from experi.run import launch as launch_experi
+
+launch_experi("demo.yml")

--- a/src/experi/run.py
+++ b/src/experi/run.py
@@ -574,6 +574,20 @@ def _set_verbosity(ctx, param, value):
         logging.basicConfig(level=logging.DEBUG)
 
 
+def launch(input_file="experiment.yml", use_dependencies=False, dry_run=False) -> None:
+    # This function provides an API to access experi's functionality from within
+    # python scripts, as an alternative to the command-line interface
+
+    # Process and run commands
+    input_file = Path(input_file)
+    structure = read_file(input_file)
+    scheduler = process_scheduler(structure)
+    jobs = process_structure(
+        structure, scheduler, Path(input_file.parent), use_dependencies
+    )
+    run_jobs(jobs, scheduler, input_file.parent, dry_run)
+
+
 @click.command()
 @click.version_option()
 @click.option(
@@ -606,11 +620,4 @@ def _set_verbosity(ctx, param, value):
     help="Increase the verbosity of logging events.",
 )
 def main(input_file, use_dependencies, dry_run) -> None:
-    # Process and run commands
-    input_file = Path(input_file)
-    structure = read_file(input_file)
-    scheduler = process_scheduler(structure)
-    jobs = process_structure(
-        structure, scheduler, Path(input_file.parent), use_dependencies
-    )
-    run_jobs(jobs, scheduler, input_file.parent, dry_run)
+    launch(input_file, use_dependencies, dry_run)


### PR DESCRIPTION
This PR contains a few small fixes which are needed in order to get any jobs to run on the SLURM scheduler.

The point of this isn't so much to be merged, but more that I couldn't be bothered to make separate issues for each one of these errors.

It contains one error to do with the job name, one to do with how job arrays are specified, one to do with cpus per task, plus a hack I had to put in because of the time conversion I mentioned in another issue.